### PR TITLE
[ENH] Initial cupy implementation to leverage GPU

### DIFF
--- a/examples/example_experimental_data.py
+++ b/examples/example_experimental_data.py
@@ -9,9 +9,8 @@ Source data should a sequence of 2D or 3D data, the temporal dimension being the
 The available denoising methods are "nordic", "mp-pca", "hybrid-pca", "opt-fro", "opt-nuc" and "opt-op".
 """
 
-from patch_denoise.simulation.phantom import mr_shepp_logan_t2_star, g_factor_map
-from patch_denoise.simulation.activations import add_frames
-from patch_denoise.simulation.noise import add_temporal_gaussian_noise
+import nibabel as nib
+from patch_denoise.space_time.lowrank import OptimalSVDDenoiser
 
 # %%
 # Setup the parameters for the simulation and noise
@@ -20,3 +19,18 @@ SHAPE = (64, 64, 64)
 N_FRAMES = 200
 
 NOISE_LEVEL = 2
+
+input_path = "/data/parietal/store2/data/ibc/3mm/sub-01/ses-00/func/wrdcsub-01_ses-00_task-ArchiSocial_dir-ap_bold.nii.gz"
+output_path = "/scratch/ymzayek/retreat_data/output.nii"
+
+img = nib.load(input_path)
+
+# data shape is (53, 63, 52, 262) with 3mm resolution
+patch_shape = (11, 11, 11)
+patch_overlap = (5)
+
+# initialize denoiser
+optimal_llr = OptimalSVDDenoiser(patch_shape, patch_overlap)
+
+# denoise image
+denoised = optimal_llr.denoise(img.get_fdata())

--- a/examples/example_experimental_data.py
+++ b/examples/example_experimental_data.py
@@ -28,7 +28,7 @@ img = nib.load(input_path)
 
 # data shape is (53, 63, 52, 262) with 3mm resolution
 patch_shape = (11, 11, 11)
-patch_overlap = (5)
+patch_overlap = (1)
 
 # initialize denoiser
 optimal_llr = OptimalSVDDenoiser(patch_shape, patch_overlap)

--- a/examples/example_experimental_data.py
+++ b/examples/example_experimental_data.py
@@ -11,6 +11,7 @@ The available denoising methods are "nordic", "mp-pca", "hybrid-pca", "opt-fro",
 
 import nibabel as nib
 from patch_denoise.space_time.lowrank import OptimalSVDDenoiser
+import timeit
 
 # %%
 # Setup the parameters for the simulation and noise
@@ -27,10 +28,12 @@ img = nib.load(input_path)
 
 # data shape is (53, 63, 52, 262) with 3mm resolution
 patch_shape = (11, 11, 11)
-patch_overlap = (5)
+patch_overlap = (10)
 
 # initialize denoiser
 optimal_llr = OptimalSVDDenoiser(patch_shape, patch_overlap)
 
 # denoise image
+time_start = timeit.default_timer()
 denoised = optimal_llr.denoise(img.get_fdata())
+print(timeit.default_timer() - time_start)

--- a/examples/example_experimental_data.py
+++ b/examples/example_experimental_data.py
@@ -28,7 +28,7 @@ img = nib.load(input_path)
 
 # data shape is (53, 63, 52, 262) with 3mm resolution
 patch_shape = (11, 11, 11)
-patch_overlap = (10)
+patch_overlap = (5)
 
 # initialize denoiser
 optimal_llr = OptimalSVDDenoiser(patch_shape, patch_overlap)

--- a/examples/example_experimental_data.py
+++ b/examples/example_experimental_data.py
@@ -35,5 +35,5 @@ optimal_llr = OptimalSVDDenoiser(patch_shape, patch_overlap)
 
 # denoise image
 time_start = timeit.default_timer()
-denoised = optimal_llr.denoise(img.get_fdata())
+denoised = optimal_llr.denoise(img.get_fdata(), engine="gpu")
 print(timeit.default_timer() - time_start)

--- a/src/patch_denoise/space_time/base.py
+++ b/src/patch_denoise/space_time/base.py
@@ -5,6 +5,7 @@ import numpy as np
 from tqdm.auto import tqdm
 import cupy as cp
 import pdb
+import timeit
 
 from .._docs import fill_doc
 
@@ -51,6 +52,7 @@ class BaseSpaceTimeDenoiser(abc.ABC):
         -------
         $denoise_return
         """
+        time_start = timeit.default_timer()
         data_shape = input_data.shape
         output_data = np.zeros_like(input_data)
         rank_map = np.zeros(data_shape[:-1], dtype=np.int32)
@@ -104,21 +106,6 @@ class BaseSpaceTimeDenoiser(abc.ABC):
             engine="gpu",
             **self.input_denoising_kwargs,
         )
-
-        # # Define the shape of the array, the patch, and the step
-        # array_shape = p_denoise.shape
-
-        # # Calculate the top-left corner of each patch
-        # patch_tl = np.array(np.meshgrid(
-        #     *[range(0, dim - ps + 1, step+1) for dim, ps in zip(array_shape, patch_shape)]
-        # )).T.reshape(-1, 3)
-
-        # # Calculate the center of each patch
-        # patch_centers = patch_tl + np.array(patch_shape) // 2
-
-        # print(len(patch_centers))
-
-        exit(0)
 
         # discard useless patches
         patch_locs = get_patch_locs(patch_shape, patch_overlap, data_shape[:-1])
@@ -182,6 +169,9 @@ class BaseSpaceTimeDenoiser(abc.ABC):
             rank_map[patch_center_img] = maxidx
             if progbar:
                 progbar.update()
+        print(timeit.default_timer() - time_start)
+
+        exit(0)
         # Averaging the overlapping pixels.
         # this is only required for averaging recombinations.
         if self.recombination in ["average", "weighted"]:

--- a/src/patch_denoise/space_time/base.py
+++ b/src/patch_denoise/space_time/base.py
@@ -105,6 +105,19 @@ class BaseSpaceTimeDenoiser(abc.ABC):
             **self.input_denoising_kwargs,
         )
 
+        # # Define the shape of the array, the patch, and the step
+        # array_shape = p_denoise.shape
+
+        # # Calculate the top-left corner of each patch
+        # patch_tl = np.array(np.meshgrid(
+        #     *[range(0, dim - ps + 1, step+1) for dim, ps in zip(array_shape, patch_shape)]
+        # )).T.reshape(-1, 3)
+
+        # # Calculate the center of each patch
+        # patch_centers = patch_tl + np.array(patch_shape) // 2
+
+        # print(len(patch_centers))
+
         exit(0)
 
         # discard useless patches

--- a/src/patch_denoise/space_time/base.py
+++ b/src/patch_denoise/space_time/base.py
@@ -90,9 +90,10 @@ class BaseSpaceTimeDenoiser(abc.ABC):
             progbar.reset(total=len(patch_locs))
         print(input_data.shape)
         step = patch_shape[0] - patch_overlap[0]
-        patches = cp.lib.stride_tricks.sliding_window_view(input_data, patch_shape, axis=(0, 1, 2))[::step, :]
+        patches = cp.lib.stride_tricks.sliding_window_view(
+            input_data, patch_shape, axis=(0, 1, 2)
+        )[::step, ::step, ::step]
         print(patches.shape)
-        exit(0)
 
         for patch_tl in patch_locs:
             patch_slice = tuple(

--- a/src/patch_denoise/space_time/base.py
+++ b/src/patch_denoise/space_time/base.py
@@ -95,10 +95,10 @@ class BaseSpaceTimeDenoiser(abc.ABC):
         )[::step, ::step, ::step]
         print(patches.shape)
         # TODO patch reshape and prod step
-        patch[np.isnan(patch)] = np.mean(patch)
+        patches[cp.isnan(patches)] = np.mean(patches)
         p_denoise, maxidx, noise_var = self._patch_processing(
-            patch,
-            patch_slice=patch_slice,
+            patches,
+            patch_slice=None,
             engine="gpu",
             **self.input_denoising_kwargs,
         )

--- a/src/patch_denoise/space_time/base.py
+++ b/src/patch_denoise/space_time/base.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 from tqdm.auto import tqdm
 import cupy as cp
+import pdb
 
 from .._docs import fill_doc
 
@@ -93,9 +94,10 @@ class BaseSpaceTimeDenoiser(abc.ABC):
         patches = cp.lib.stride_tricks.sliding_window_view(
             input_data_padded, patch_shape, axis=(0, 1, 2)
         )[::step, ::step, ::step]
-        print(patches.shape)
-        # TODO patch reshape and prod step
-        patches[cp.isnan(patches)] = np.mean(patches)
+
+        patches = patches.transpose((0, 1, 2, 4, 5, 6, 3))
+        patches = patches.reshape((np.prod(patches.shape[:3]), patch_size, t_s))
+        patches[cp.isnan(patches)] = cp.mean(patches)
         p_denoise, maxidx, noise_var = self._patch_processing(
             patches,
             patch_slice=None,

--- a/src/patch_denoise/space_time/base.py
+++ b/src/patch_denoise/space_time/base.py
@@ -3,6 +3,7 @@ import abc
 import logging
 import numpy as np
 from tqdm.auto import tqdm
+import cupy as cp
 
 from .._docs import fill_doc
 
@@ -87,6 +88,11 @@ class BaseSpaceTimeDenoiser(abc.ABC):
             progbar = tqdm(total=len(patch_locs))
         elif progbar is not False:
             progbar.reset(total=len(patch_locs))
+        print(input_data.shape)
+        step = patch_shape[0] - patch_overlap[0]
+        patches = cp.lib.stride_tricks.sliding_window_view(input_data, patch_shape, axis=(0, 1, 2))[::step, :]
+        print(patches.shape)
+        exit(0)
 
         for patch_tl in patch_locs:
             patch_slice = tuple(

--- a/src/patch_denoise/space_time/base.py
+++ b/src/patch_denoise/space_time/base.py
@@ -88,13 +88,32 @@ class BaseSpaceTimeDenoiser(abc.ABC):
             progbar = tqdm(total=len(patch_locs))
         elif progbar is not False:
             progbar.reset(total=len(patch_locs))
-        print(input_data.shape)
+
+        # Pad the data
+
+        output_data = cp.asarray(output_data)
+
+        input_data = cp.asarray(input_data)
+
+        c, h, w, t_s = input_data.shape
+        kc, kh, kw = patch_shape  # kernel size
+        sc, sh, sw = np.repeat(
+            patch_shape[0] - patch_overlap[0], len(patch_shape)
+        )
+        needed_c = int((cp.ceil((c - kc) / sc + 1) - ((c - kc) / sc + 1)) * kc)
+        needed_h = int((cp.ceil((h - kh) / sh + 1) - ((h - kh) / sh + 1)) * kh)
+        needed_w = int((cp.ceil((w - kw) / sw + 1) - ((w - kw) / sw + 1)) * kw)
+
+        input_data_padded = cp.pad(
+            input_data, ((0, needed_c), (0, needed_h), (0, needed_w), (0, 0)
+        ), mode='edge')
+
         step = patch_shape[0] - patch_overlap[0]
         patches = cp.lib.stride_tricks.sliding_window_view(
-            input_data, patch_shape, axis=(0, 1, 2)
+            input_data_padded, patch_shape, axis=(0, 1, 2)
         )[::step, ::step, ::step]
         print(patches.shape)
-
+        exit(0)
         for patch_tl in patch_locs:
             patch_slice = tuple(
                 slice(tl, tl + ps) for tl, ps in zip(patch_tl, patch_shape)

--- a/src/patch_denoise/space_time/lowrank.py
+++ b/src/patch_denoise/space_time/lowrank.py
@@ -4,6 +4,7 @@ from types import MappingProxyType
 import numpy as np
 from scipy.linalg import svd
 from scipy.optimize import minimize
+import cupy
 
 from .base import BaseSpaceTimeDenoiser
 from .utils import (
@@ -373,26 +374,56 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         shrink_func=None,
         mp_median=None,
         var_apriori=None,
+        engine="gpu",
     ):
-        u_vec, s_values, v_vec, p_tmean = svd_analysis(patch)
-        if var_apriori is not None:
-            sigma = np.mean(np.sqrt(var_apriori[patch_slice]))
-        else:
-            sigma = np.median(s_values) / np.sqrt(patch.shape[1] * mp_median)
+        if engine == "cpu":
+            u_vec, s_values, v_vec, p_tmean = svd_analysis(patch)
+            if var_apriori is not None:
+                sigma = np.mean(np.sqrt(var_apriori[patch_slice]))
+            else:
+                sigma = np.median(s_values) / np.sqrt(patch.shape[1] * mp_median)
 
-        scale_factor = np.sqrt(patch.shape[1]) * sigma
-        thresh_s_values = scale_factor * shrink_func(
-            s_values / scale_factor,
-            beta=patch.shape[1] / patch.shape[0],
-        )
-        thresh_s_values[np.isnan(thresh_s_values)] = 0
+            scale_factor = np.sqrt(patch.shape[1]) * sigma
+            thresh_s_values = scale_factor * shrink_func(
+                s_values / scale_factor,
+                beta=patch.shape[1] / patch.shape[0],
+            )
+            thresh_s_values[np.isnan(thresh_s_values)] = 0
 
-        if np.any(thresh_s_values):
-            maxidx = np.max(np.nonzero(thresh_s_values)) + 1
-            p_new = svd_synthesis(u_vec, thresh_s_values, v_vec, p_tmean, maxidx)
-        else:
-            maxidx = 0
-            p_new = np.zeros_like(patch) + p_tmean
+            if np.any(thresh_s_values):
+                maxidx = np.max(np.nonzero(thresh_s_values)) + 1
+                p_new = svd_synthesis(u_vec, thresh_s_values, v_vec, p_tmean, maxidx)
+            else:
+                maxidx = 0
+                p_new = np.zeros_like(patch) + p_tmean
+
+        if engine == "gpu":
+            u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
+            if var_apriori is not None:
+                sigma = cupy.mean(cupy.sqrt(var_apriori[patch_slice]))
+            else:
+                sigma = cupy.median(s_values) / cupy.sqrt(
+                    patch.shape[1] * mp_median
+                )
+
+            scale_factor = cupy.sqrt(patch.shape[1]) * sigma
+            thresh_s_values = cupy.array(scale_factor * shrink_func(
+                s_values / scale_factor,
+                beta=patch.shape[1] / patch.shape[0],
+            ))
+            thresh_s_values[cupy.isnan(thresh_s_values)] = 0
+
+            if cupy.any(thresh_s_values):
+                maxidx = cupy.amax(cupy.array(
+                    cupy.nonzero(thresh_s_values)
+                ) + 1)
+                print(maxidx)
+                p_new = svd_synthesis(
+                    u_vec, thresh_s_values, v_vec, p_tmean, maxidx
+                )
+            else:
+                maxidx = 0
+                p_new = cupy.zeros_like(patch) + p_tmean
 
         return p_new, maxidx, np.NaN
 

--- a/src/patch_denoise/space_time/lowrank.py
+++ b/src/patch_denoise/space_time/lowrank.py
@@ -379,7 +379,6 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         var_apriori=None,
         engine="cpu",
     ):
-        # TODO check matching of shapes and reshape to work with same indexes
         u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
         if engine == "cpu":
             if var_apriori is not None:

--- a/src/patch_denoise/space_time/lowrank.py
+++ b/src/patch_denoise/space_time/lowrank.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 import numpy as np
 from scipy.linalg import svd
 from scipy.optimize import minimize
-import cupy
+import cupy as cp
 
 from .base import BaseSpaceTimeDenoiser
 from .utils import (
@@ -376,54 +376,54 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         var_apriori=None,
         engine="gpu",
     ):
-        if engine == "cpu":
-            u_vec, s_values, v_vec, p_tmean = svd_analysis(patch)
-            if var_apriori is not None:
-                sigma = np.mean(np.sqrt(var_apriori[patch_slice]))
-            else:
-                sigma = np.median(s_values) / np.sqrt(patch.shape[1] * mp_median)
 
-            scale_factor = np.sqrt(patch.shape[1]) * sigma
-            thresh_s_values = scale_factor * shrink_func(
-                s_values / scale_factor,
-                beta=patch.shape[1] / patch.shape[0],
-            )
-            thresh_s_values[np.isnan(thresh_s_values)] = 0
+        u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
+        if var_apriori is not None:
+            sigma = np.mean(np.sqrt(var_apriori[patch_slice]))
+        else:
+            sigma = np.median(s_values) / np.sqrt(patch.shape[1] * mp_median)
 
-            if np.any(thresh_s_values):
-                maxidx = np.max(np.nonzero(thresh_s_values)) + 1
-                p_new = svd_synthesis(u_vec, thresh_s_values, v_vec, p_tmean, maxidx)
-            else:
-                maxidx = 0
-                p_new = np.zeros_like(patch) + p_tmean
+        scale_factor = np.sqrt(patch.shape[1]) * sigma
+        thresh_s_values = scale_factor * shrink_func(
+            s_values / scale_factor,
+            beta=patch.shape[1] / patch.shape[0],
+        )
+        thresh_s_values[np.isnan(thresh_s_values)] = 0
 
-        if engine == "gpu":
-            u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
-            if var_apriori is not None:
-                sigma = cupy.mean(cupy.sqrt(var_apriori[patch_slice]))
-            else:
-                sigma = cupy.median(s_values) / cupy.sqrt(
-                    patch.shape[1] * mp_median
-                )
+        if np.any(thresh_s_values):
+            maxidx = np.max(np.nonzero(thresh_s_values)) + 1
+            p_new = svd_synthesis(u_vec, thresh_s_values, v_vec, p_tmean, maxidx)
+        else:
+            maxidx = 0
+            p_new = np.zeros_like(patch) + p_tmean
 
-            scale_factor = cupy.sqrt(patch.shape[1]) * sigma
-            thresh_s_values = cupy.array(scale_factor * shrink_func(
-                s_values / scale_factor,
-                beta=patch.shape[1] / patch.shape[0],
-            ))
-            thresh_s_values[cupy.isnan(thresh_s_values)] = 0
-
-            if cupy.any(thresh_s_values):
-                maxidx = cupy.amax(cupy.array(
-                    cupy.nonzero(thresh_s_values)
-                ) + 1)
-                print(maxidx)
-                p_new = svd_synthesis(
-                    u_vec, thresh_s_values, v_vec, p_tmean, maxidx
-                )
-            else:
-                maxidx = 0
-                p_new = cupy.zeros_like(patch) + p_tmean
+#        if engine == "gpu":
+#            u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
+#            if var_apriori is not None:
+#                sigma = cp.mean(cp.sqrt(var_apriori[patch_slice]))
+#            else:
+#                sigma = cp.median(s_values) / cp.sqrt(
+#                    patch.shape[1] * mp_median
+#                )
+#
+#            scale_factor = cp.sqrt(patch.shape[1]) * sigma
+#            thresh_s_values = cp.array(scale_factor * shrink_func(
+#                s_values / scale_factor,
+#                beta=patch.shape[1] / patch.shape[0],
+#            ))
+#            thresh_s_values[cp.isnan(thresh_s_values)] = 0
+#
+#            if cp.any(thresh_s_values):
+#                maxidx = cp.amax(cp.array(
+#                    cp.nonzero(thresh_s_values)
+#                ) + 1)
+#                print(maxidx)
+#                p_new = svd_synthesis(
+#                    u_vec, thresh_s_values, v_vec, p_tmean, maxidx
+#                )
+#            else:
+#                maxidx = 0
+#                p_new = cp.zeros_like(patch) + p_tmean
 
         return p_new, maxidx, np.NaN
 

--- a/src/patch_denoise/space_time/lowrank.py
+++ b/src/patch_denoise/space_time/lowrank.py
@@ -374,8 +374,9 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         shrink_func=None,
         mp_median=None,
         var_apriori=None,
-        engine="gpu",
+        engine="cpu",
     ):
+        # TODO check matching of shapes and reshape to work with same indexes
         u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
         if var_apriori is not None:
             sigma = np.mean(np.sqrt(var_apriori[patch_slice]))

--- a/src/patch_denoise/space_time/lowrank.py
+++ b/src/patch_denoise/space_time/lowrank.py
@@ -321,6 +321,7 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         noise_std=None,
         eps_marshenko_pastur=1e-7,
         progbar=None,
+        engine="cpu",
     ):
         """
         Optimal thresholing denoising method.
@@ -365,7 +366,9 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         else:
             self.input_denoising_kwargs["var_apriori"] = noise_std**2
 
-        return super().denoise(input_data, mask, mask_threshold, progbar=progbar)
+        return super().denoise(
+            input_data, mask, mask_threshold, progbar=progbar, engine=engine
+        )
 
     def _patch_processing(
         self,

--- a/src/patch_denoise/space_time/lowrank.py
+++ b/src/patch_denoise/space_time/lowrank.py
@@ -376,10 +376,7 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         var_apriori=None,
         engine="gpu",
     ):
-        if engine == "gpu":
-           u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
-        elif engine == "cpu":
-           u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
+        u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
         if var_apriori is not None:
             sigma = np.mean(np.sqrt(var_apriori[patch_slice]))
         else:
@@ -394,38 +391,12 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
 
         if np.any(thresh_s_values):
             maxidx = np.max(np.nonzero(thresh_s_values)) + 1
-            p_new = svd_synthesis(u_vec, thresh_s_values, v_vec, p_tmean, maxidx)
+            p_new = svd_synthesis(
+                u_vec, thresh_s_values, v_vec, p_tmean, maxidx, engine=engine
+            )
         else:
             maxidx = 0
             p_new = np.zeros_like(patch) + p_tmean
-
-    #    if engine == "gpu":
-    #        u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
-    #        if var_apriori is not None:
-    #            sigma = cp.mean(cp.sqrt(var_apriori[patch_slice]))
-    #        else:
-    #            sigma = cp.median(s_values) / cp.sqrt(
-    #                patch.shape[1] * mp_median
-    #            )
-
-    #        scale_factor = cp.sqrt(patch.shape[1]) * sigma
-    #        thresh_s_values = cp.array(scale_factor * shrink_func(
-    #            s_values / scale_factor,
-    #            beta=patch.shape[1] / patch.shape[0],
-    #        ))
-    #        thresh_s_values[cp.isnan(thresh_s_values)] = 0
-
-    #        if cp.any(thresh_s_values):
-    #            maxidx = cp.amax(cp.array(
-    #                cp.nonzero(thresh_s_values)
-    #            ) + 1)
-    #            print(maxidx)
-    #            p_new = svd_synthesis(
-    #                u_vec, thresh_s_values, v_vec, p_tmean, maxidx
-    #            )
-    #        else:
-    #            maxidx = 0
-    #            p_new = cp.zeros_like(patch) + p_tmean
 
         return p_new, maxidx, np.NaN
 

--- a/src/patch_denoise/space_time/lowrank.py
+++ b/src/patch_denoise/space_time/lowrank.py
@@ -376,8 +376,10 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
         var_apriori=None,
         engine="gpu",
     ):
-
-        u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
+        if engine == "gpu":
+           u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
+        elif engine == "cpu":
+           u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
         if var_apriori is not None:
             sigma = np.mean(np.sqrt(var_apriori[patch_slice]))
         else:
@@ -397,33 +399,33 @@ class OptimalSVDDenoiser(BaseSpaceTimeDenoiser):
             maxidx = 0
             p_new = np.zeros_like(patch) + p_tmean
 
-#        if engine == "gpu":
-#            u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
-#            if var_apriori is not None:
-#                sigma = cp.mean(cp.sqrt(var_apriori[patch_slice]))
-#            else:
-#                sigma = cp.median(s_values) / cp.sqrt(
-#                    patch.shape[1] * mp_median
-#                )
-#
-#            scale_factor = cp.sqrt(patch.shape[1]) * sigma
-#            thresh_s_values = cp.array(scale_factor * shrink_func(
-#                s_values / scale_factor,
-#                beta=patch.shape[1] / patch.shape[0],
-#            ))
-#            thresh_s_values[cp.isnan(thresh_s_values)] = 0
-#
-#            if cp.any(thresh_s_values):
-#                maxidx = cp.amax(cp.array(
-#                    cp.nonzero(thresh_s_values)
-#                ) + 1)
-#                print(maxidx)
-#                p_new = svd_synthesis(
-#                    u_vec, thresh_s_values, v_vec, p_tmean, maxidx
-#                )
-#            else:
-#                maxidx = 0
-#                p_new = cp.zeros_like(patch) + p_tmean
+    #    if engine == "gpu":
+    #        u_vec, s_values, v_vec, p_tmean = svd_analysis(patch, engine=engine)
+    #        if var_apriori is not None:
+    #            sigma = cp.mean(cp.sqrt(var_apriori[patch_slice]))
+    #        else:
+    #            sigma = cp.median(s_values) / cp.sqrt(
+    #                patch.shape[1] * mp_median
+    #            )
+
+    #        scale_factor = cp.sqrt(patch.shape[1]) * sigma
+    #        thresh_s_values = cp.array(scale_factor * shrink_func(
+    #            s_values / scale_factor,
+    #            beta=patch.shape[1] / patch.shape[0],
+    #        ))
+    #        thresh_s_values[cp.isnan(thresh_s_values)] = 0
+
+    #        if cp.any(thresh_s_values):
+    #            maxidx = cp.amax(cp.array(
+    #                cp.nonzero(thresh_s_values)
+    #            ) + 1)
+    #            print(maxidx)
+    #            p_new = svd_synthesis(
+    #                u_vec, thresh_s_values, v_vec, p_tmean, maxidx
+    #            )
+    #        else:
+    #            maxidx = 0
+    #            p_new = cp.zeros_like(patch) + p_tmean
 
         return p_new, maxidx, np.NaN
 

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -3,6 +3,7 @@ import numpy as np
 from scipy.integrate import quad
 from scipy.linalg import eigh, svd
 import cupy as cp
+import pdb
 
 
 def svd_analysis(input_data, engine="cpu"):
@@ -20,8 +21,6 @@ def svd_analysis(input_data, engine="cpu"):
     -------
     u_vec, s_vals, v_vec, mean
     """
-    mean = np.mean(input_data, axis=0)
-    data_centered = input_data - mean
     # TODO  benchmark svd vs svds and order of data.
     if engine == "cpu":
         mean = np.mean(input_data, axis=0)
@@ -36,6 +35,7 @@ def svd_analysis(input_data, engine="cpu"):
         u_vec = cp.asnumpy(u_vec)
         s_vals = cp.asnumpy(s_vals)
         v_vec = cp.asnumpy(v_vec)
+        mean = cp.asnumpy(mean)
 
     return u_vec, s_vals, v_vec, mean
 
@@ -58,7 +58,9 @@ def svd_synthesis(u_vec, s_vals, v_vec, mean, idx):
     -------
     np.ndarray: The reconstructed matrix.
     """
-    return (u_vec[:, :idx] @ (s_vals[:idx, None] * v_vec[:idx, :])) + mean
+    return (
+        u_vec[..., :idx] @ (s_vals[:idx, ..., None] * v_vec[:idx, ...])
+    ) + mean
 
 
 def eig_analysis(input_data, max_eig_val=10):

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -2,9 +2,10 @@
 import numpy as np
 from scipy.integrate import quad
 from scipy.linalg import eigh, svd
+import cupy
 
 
-def svd_analysis(input_data):
+def svd_analysis(input_data, engine="cpu"):
     """Return the centered SVD decomposition.
 
     U, S, Vt and M are compute such that:
@@ -22,7 +23,16 @@ def svd_analysis(input_data):
     mean = np.mean(input_data, axis=0)
     data_centered = input_data - mean
     # TODO  benchmark svd vs svds and order of data.
-    u_vec, s_vals, v_vec = svd(data_centered, full_matrices=False)
+    if engine == "cpu":
+        u_vec, s_vals, v_vec = svd(data_centered, full_matrices=False)
+    elif engine == "gpu":
+        data_centered = cupy.array(data_centered)
+        u_vec, s_vals, v_vec = cupy.linalg.svd(
+            data_centered, full_matrices=False
+        )
+#        u_vec = cupy.asnumpy(u_vec)
+#        s_vals = cupy.asnumpy(s_vals)
+#        v_vec = cupy.asnumpy(v_vec)
 
     return u_vec, s_vals, v_vec, mean
 

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -24,9 +24,12 @@ def svd_analysis(input_data, engine="cpu"):
     data_centered = input_data - mean
     # TODO  benchmark svd vs svds and order of data.
     if engine == "cpu":
+        mean = np.mean(input_data, axis=0)
+        data_centered = input_data - mean
         u_vec, s_vals, v_vec = svd(data_centered, full_matrices=False)
     elif engine == "gpu":
-        data_centered = cp.array(data_centered)
+        mean = cp.mean(input_data, axis=0)
+        data_centered = input_data - mean
         u_vec, s_vals, v_vec = cp.linalg.svd(
             data_centered, full_matrices=False
         )

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -31,15 +31,15 @@ def svd_analysis(input_data, engine="cpu"):
         u_vec, s_vals, v_vec = cp.linalg.svd(
             data_centered, full_matrices=False
         )
-        u_vec = cp.asnumpy(u_vec)
-        s_vals = cp.asnumpy(s_vals)
-        v_vec = cp.asnumpy(v_vec)
-        mean = cp.asnumpy(mean)
+        # u_vec = cp.asnumpy(u_vec)
+        # s_vals = cp.asnumpy(s_vals)
+        # v_vec = cp.asnumpy(v_vec)
+        # mean = cp.asnumpy(mean)
 
     return u_vec, s_vals, v_vec, mean
 
 
-def svd_synthesis(u_vec, s_vals, v_vec, mean, idx, engine="cpu"):
+def svd_synthesis(u_vec, s_vals, v_vec, mean, idx):
     """
     Reconstruct ``X = (U @ (S * V)) + M`` with only the max_idx greatest component.
 
@@ -57,13 +57,7 @@ def svd_synthesis(u_vec, s_vals, v_vec, mean, idx, engine="cpu"):
     -------
     np.ndarray: The reconstructed matrix.
     """
-    # TODO check shapes
-    if engine == "cpu":
-        return (u_vec[:, :idx] @ (s_vals[:idx, None] * v_vec[:idx, :])) + mean
-    if engine == "gpu":
-        return (
-            u_vec[..., :idx] @ (s_vals[:idx, ..., None] * v_vec[:idx, ...])
-        ) + mean
+    return (u_vec[:, :idx] @ (s_vals[:idx, None] * v_vec[:idx, :])) + mean
 
 
 def eig_analysis(input_data, max_eig_val=10):

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -40,7 +40,7 @@ def svd_analysis(input_data, engine="cpu"):
     return u_vec, s_vals, v_vec, mean
 
 
-def svd_synthesis(u_vec, s_vals, v_vec, mean, idx):
+def svd_synthesis(u_vec, s_vals, v_vec, mean, idx, engine="cpu"):
     """
     Reconstruct ``X = (U @ (S * V)) + M`` with only the max_idx greatest component.
 
@@ -58,9 +58,12 @@ def svd_synthesis(u_vec, s_vals, v_vec, mean, idx):
     -------
     np.ndarray: The reconstructed matrix.
     """
-    return (
-        u_vec[..., :idx] @ (s_vals[:idx, ..., None] * v_vec[:idx, ...])
-    ) + mean
+    if engine == "cpu":
+        return (u_vec[:, :idx] @ (s_vals[:idx, None] * v_vec[:idx, :])) + mean
+    if engine == "gpu":
+        return (
+            u_vec[..., :idx] @ (s_vals[:idx, ..., None] * v_vec[:idx, ...])
+        ) + mean
 
 
 def eig_analysis(input_data, max_eig_val=10):

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -3,7 +3,6 @@ import numpy as np
 from scipy.integrate import quad
 from scipy.linalg import eigh, svd
 import cupy as cp
-import pdb
 
 
 def svd_analysis(input_data, engine="cpu"):

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -58,6 +58,7 @@ def svd_synthesis(u_vec, s_vals, v_vec, mean, idx, engine="cpu"):
     -------
     np.ndarray: The reconstructed matrix.
     """
+    # TODO check shapes
     if engine == "cpu":
         return (u_vec[:, :idx] @ (s_vals[:idx, None] * v_vec[:idx, :])) + mean
     if engine == "gpu":

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -2,7 +2,7 @@
 import numpy as np
 from scipy.integrate import quad
 from scipy.linalg import eigh, svd
-import cupy
+import cupy as cp
 
 
 def svd_analysis(input_data, engine="cpu"):
@@ -26,13 +26,13 @@ def svd_analysis(input_data, engine="cpu"):
     if engine == "cpu":
         u_vec, s_vals, v_vec = svd(data_centered, full_matrices=False)
     elif engine == "gpu":
-        data_centered = cupy.array(data_centered)
-        u_vec, s_vals, v_vec = cupy.linalg.svd(
+        data_centered = cp.array(data_centered)
+        u_vec, s_vals, v_vec = cp.linalg.svd(
             data_centered, full_matrices=False
         )
-#        u_vec = cupy.asnumpy(u_vec)
-#        s_vals = cupy.asnumpy(s_vals)
-#        v_vec = cupy.asnumpy(v_vec)
+        u_vec = cp.asnumpy(u_vec)
+        s_vals = cp.asnumpy(s_vals)
+        v_vec = cp.asnumpy(v_vec)
 
     return u_vec, s_vals, v_vec, mean
 

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -31,10 +31,6 @@ def svd_analysis(input_data, engine="cpu"):
         u_vec, s_vals, v_vec = cp.linalg.svd(
             data_centered, full_matrices=False
         )
-        # u_vec = cp.asnumpy(u_vec)
-        # s_vals = cp.asnumpy(s_vals)
-        # v_vec = cp.asnumpy(v_vec)
-        # mean = cp.asnumpy(mean)
 
     return u_vec, s_vals, v_vec, mean
 


### PR DESCRIPTION
This is an initial implementation of cupy to replace some numpy operations to speed up computation.

It is already a bit faster especially as overlap is increased (e.g. 1.4x faster with the example in example_experimental_data.py when overlap is 5). The example as it is is runnable and you can select engine to be "cpu" or "gpu". Though patch coordinates calculated in get_patch_locs are not used anymore for extracting the patches they are still being used for the recombination as I'm still not sure how this can be done in a more efficient manner.

Note that some of the cupy code mirrors what was done with the [pytorch implementation](https://github.com/ymzayek/patch-denoising/tree/update) so before merging this code (if that happens) I'd like to give author credit to @achamma

TODO:
- Figure out other parts that can be made more efficient
- Formally compare GPU vs CPU
- ADD TESTS!