### PR TITLE
[MAINT] add dependabot to keep github action up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# Documentation
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+-   package-ecosystem: github-actions
+    directory: /
+    schedule:
+        interval: weekly


### PR DESCRIPTION
Side benefit: this will run the CI at 'fairly' regular interval and may help catch errors due to deprecated things in the dependencies.