### PR TITLE
Use phase data in main workflow and add option for phase noise map

### DIFF
--- a/src/patch_denoise/bindings/cli.py
+++ b/src/patch_denoise/bindings/cli.py
@@ -91,9 +91,14 @@ def parse_args():
         default=None,
         type=Path,
         help=(
-            "Phase of the input data. This MUST be in radian. "
+            "Phase of the input data. This MUST be in radians. "
             "No conversion would be applied."
         ),
+    )
+    parser.add_argument(
+        "--noise-map-phase",
+        default=None,
+        help="phase component of the noise map estimation file",
     )
     parser.add_argument("-v", "--verbose", action="count", default=0)
 
@@ -128,15 +133,17 @@ def main():
 
     if args.input_phase is not None:
         input_data, affine = load_complex_nifti(args.input_file, args.input_phase)
-    input_data, affine = load_as_array(args.input_file)
+    else:
+        input_data, affine = load_as_array(args.input_file)
 
     if args.nan_to_num is not None:
         input_data = np.nan_to_num(input_data, nan=args.nan_to_num)
+
     n_nans = np.isnan(input_data).sum()
     if n_nans > 0:
         logging.warning(
-            f"{n_nans}/{np.prod(input_data.shape)} voxels are NaN."
-            " You might want to use --nan-to-num=<value>",
+            f"{n_nans}/{input_data.size} voxels are NaN. "
+            "You might want to use --nan-to-num=<value>",
             stacklevel=0,
         )
 
@@ -145,14 +152,30 @@ def main():
         affine_mask = None
     else:
         mask, affine_mask = load_as_array(args.mask)
-    noise_map, affine_noise_map = load_as_array(args.noise_map)
+
+    if args.noise_map is not None and args.noise_map_phase is not None:
+        noise_map, affine_noise_map = load_complex_nifti(
+            args.noise_map,
+            args.noise_map_phase,
+        )
+    elif args.noise_map is not None:
+        noise_map, affine_noise_map = load_as_array(args.noise_map)
+    elif args.noise_map_phase is not None:
+        raise ValueError(
+            "The phase component of the noise map has been provided, "
+            "but not the magnitude."
+        )
+    else:
+        noise_map = None
+        affine_noise_map = None
 
     if affine is not None:
-        if affine_mask is not None and np.allclose(affine, affine_mask):
+        if (affine_mask is not None) and not np.allclose(affine, affine_mask):
             logging.warning(
                 "Affine matrix of input and mask does not match", stacklevel=2
             )
-        if affine_noise_map is not None and np.allclose(affine, affine_noise_map):
+
+        if (affine_noise_map is not None) and not np.allclose(affine, affine_noise_map):
             logging.warning(
                 "Affine matrix of input and noise map does not match", stacklevel=2
             )
@@ -165,6 +188,7 @@ def main():
         else:
             t = int(args.time_slice)
         d_par.patch_shape = (d_par.patch_shape,) * (input_data.ndim - 1) + (t,)
+
     print(d_par)
     denoise_func = DENOISER_MAP[d_par.method]
     extra_kwargs = dict()
@@ -179,7 +203,7 @@ def main():
         if noise_map is None:
             raise RuntimeError("A noise map must be specified for this method.")
 
-    denoised_data, patchs_weight, noise_std_map, rank_map = denoise_func(
+    denoised_data, _, noise_std_map, _ = denoise_func(
         input_data,
         patch_shape=d_par.patch_shape,
         patch_overlap=d_par.patch_overlap,

--- a/src/patch_denoise/bindings/cli.py
+++ b/src/patch_denoise/bindings/cli.py
@@ -216,7 +216,7 @@ def _get_parser():
         type=IsFile,
         help=(
             "Phase of the input data. This MUST be in radians. "
-            "No conversion would be applied."
+            "No rescaling will be applied."
         ),
     )
     data_group.add_argument(
@@ -224,7 +224,10 @@ def _get_parser():
         metavar="FILE",
         default=None,
         type=IsFile,
-        help="phase component of the noise map estimation file",
+        help=(
+            "Phase component of the noise map estimation file. "
+            "This MUST be in radians. No rescaling will be applied."
+        ),
     )
 
     misc_group = parser.add_argument_group("Miscellaneous options")

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -238,7 +238,5 @@ def estimate_noise(noise_sequence, block_size=1):
         )
         # Set the value of the voxel in the center of the patch to the SD of
         # the patch
-        patch_data = noise_sequence[patch_slice]
-        print(patch_data.shape)
         noise_map[patch_center_img] = np.std(noise_sequence[patch_slice])
     return noise_map

--- a/src/patch_denoise/space_time/utils.py
+++ b/src/patch_denoise/space_time/utils.py
@@ -238,5 +238,7 @@ def estimate_noise(noise_sequence, block_size=1):
         )
         # Set the value of the voxel in the center of the patch to the SD of
         # the patch
+        patch_data = noise_sequence[patch_slice]
+        print(patch_data.shape)
         noise_map[patch_center_img] = np.std(noise_sequence[patch_slice])
     return noise_map

--- a/tests/test_spacetime_utils.py
+++ b/tests/test_spacetime_utils.py
@@ -83,11 +83,14 @@ def test_noise_estimation(block_dim):
         print(f"Mean of raw: {np.nanmean(medium_random_matrix)}")
         print(f"Max of raw: {np.nanmax(medium_random_matrix)}")
         print(f"Min of raw: {np.nanmin(medium_random_matrix)}")
+        real_std = np.nanstd(medium_random_matrix)
+        print(f"SD of raw: {real_std}")
 
         noise_map = estimate_noise(medium_random_matrix, block_dim)
         print(f"Mean of noise map: {np.nanmean(noise_map)}")
-        real_std = np.nanstd(medium_random_matrix)
-        print(f"SD of raw: {real_std}")
+        print(f"Max of noise map: {np.nanmax(noise_map)}")
+        print(f"Min of noise map: {np.nanmin(noise_map)}")
+        print(f"SD of noise map: {np.nanstd(noise_map)}")
         err = np.nanmean(noise_map - real_std)
         print(f"Err: {err}")
         assert err <= 0.1 * real_std

--- a/tests/test_spacetime_utils.py
+++ b/tests/test_spacetime_utils.py
@@ -71,11 +71,17 @@ def test_marshenko_pastur_median(beta, rng, n_runs=10000, n_samples=1000):
 
 @pytest.mark.parametrize("block_dim", range(5, 10))
 def test_noise_estimation(medium_random_matrix, block_dim):
-    """Test noise estimation."""
-    noise_map = estimate_noise(medium_random_matrix, block_dim)
+    """Test noise estimation.
 
+    The mean patch-wise standard deviation should be close to the overall
+    standard deviation.
+    """
+    noise_map = estimate_noise(medium_random_matrix, block_dim)
+    print(np.nanmean(noise_map))
     real_std = np.nanstd(medium_random_matrix)
+    print(real_std)
     err = np.nanmean(noise_map - real_std)
+    print(err)
     assert err <= 0.1 * real_std
 
 

--- a/tests/test_spacetime_utils.py
+++ b/tests/test_spacetime_utils.py
@@ -76,7 +76,7 @@ def test_noise_estimation(block_dim):
     The mean patch-wise standard deviation should be close to the overall
     standard deviation.
     """
-    for seed in range(10):
+    for seed in range(15):
         print(f"Seed: {seed}")
         rng = np.random.RandomState(seed)
         medium_random_matrix = rng.randn(200, 200, 100)

--- a/tests/test_spacetime_utils.py
+++ b/tests/test_spacetime_utils.py
@@ -76,12 +76,14 @@ def test_noise_estimation(medium_random_matrix, block_dim):
     The mean patch-wise standard deviation should be close to the overall
     standard deviation.
     """
+    print(f"Max of raw: {np.nanmax(medium_random_matrix)}")
+    print(f"Min of raw: {np.nanmin(medium_random_matrix)}")
     noise_map = estimate_noise(medium_random_matrix, block_dim)
-    print(np.nanmean(noise_map))
+    print(f"Mean of noise map: {np.nanmean(noise_map)}")
     real_std = np.nanstd(medium_random_matrix)
-    print(real_std)
+    print(f"SD of raw: {real_std}")
     err = np.nanmean(noise_map - real_std)
-    print(err)
+    print(f"Err: {err}")
     assert err <= 0.1 * real_std
 
 

--- a/tests/test_spacetime_utils.py
+++ b/tests/test_spacetime_utils.py
@@ -70,21 +70,27 @@ def test_marshenko_pastur_median(beta, rng, n_runs=10000, n_samples=1000):
 
 
 @pytest.mark.parametrize("block_dim", range(5, 10))
-def test_noise_estimation(medium_random_matrix, block_dim):
+def test_noise_estimation(block_dim):
     """Test noise estimation.
 
     The mean patch-wise standard deviation should be close to the overall
     standard deviation.
     """
-    print(f"Max of raw: {np.nanmax(medium_random_matrix)}")
-    print(f"Min of raw: {np.nanmin(medium_random_matrix)}")
-    noise_map = estimate_noise(medium_random_matrix, block_dim)
-    print(f"Mean of noise map: {np.nanmean(noise_map)}")
-    real_std = np.nanstd(medium_random_matrix)
-    print(f"SD of raw: {real_std}")
-    err = np.nanmean(noise_map - real_std)
-    print(f"Err: {err}")
-    assert err <= 0.1 * real_std
+    for seed in range(10):
+        print(f"Seed: {seed}")
+        rng = np.random.RandomState(seed)
+        medium_random_matrix = rng.randn(200, 200, 100)
+        print(f"Mean of raw: {np.nanmean(medium_random_matrix)}")
+        print(f"Max of raw: {np.nanmax(medium_random_matrix)}")
+        print(f"Min of raw: {np.nanmin(medium_random_matrix)}")
+
+        noise_map = estimate_noise(medium_random_matrix, block_dim)
+        print(f"Mean of noise map: {np.nanmean(noise_map)}")
+        real_std = np.nanstd(medium_random_matrix)
+        print(f"SD of raw: {real_std}")
+        err = np.nanmean(noise_map - real_std)
+        print(f"Err: {err}")
+        assert err <= 0.1 * real_std
 
 
 @parametrize_random_matrix


### PR DESCRIPTION
Closes #8.

Changes proposed:

- Fix a bug in the main workflow where phase data were not loaded.
- Add a new parameter, `--noise-map-phase`, for the phase component of the noise map.
    - I'm not actually sure what rescaling should be done before this map is passed along to patch-denoise, since the phase data need to be in radians ahead of time.
- Fix affine checks. Before it would raise a warning if the affines _did_ match.