### PR TITLE
Add individual options as alternative to configuration string

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,3 +9,82 @@ but it can take advantage of reconstructed phase data and/or noise volumes.
    :ref: patch_denoise.bindings.cli._get_parser
    :prog: patch-denoise
    :func: _get_parser
+
+
+================================
+Using patch-denoise on BIDS data
+================================
+
+.. warning::
+    These examples assume that the phase data are in radians.
+    If they are in arbitrary units,
+    you will need to rescale them before running patch-denoise.
+
+
+Magnitude only
+==============
+
+.. code-block:: bash
+
+    patch-denoise \
+        sub-01/func/sub-01_task-rest_part-mag_bold.nii.gz \
+        sub-01_task-rest_part-mag_desc-denoised_bold.nii.gz \
+        --mask auto \
+        --method optimal-fro \
+        --patch-shape 11 \
+        --patch-overlap 5 \
+        --recombination weighted \
+        --mask-threshold 1
+
+
+Magnitude with noise volumes
+============================
+
+.. code-block:: bash
+
+    patch-denoise \
+        sub-01/func/sub-01_task-rest_part-mag_bold.nii.gz \
+        sub-01_task-rest_part-mag_desc-denoised_bold.nii.gz \
+        --noise-map sub-01/func/sub-01_task-rest_part-mag_noRF.nii.gz \
+        --mask auto \
+        --method optimal-fro \
+        --patch-shape 11 \
+        --patch-overlap 5 \
+        --recombination weighted \
+        --mask-threshold 1
+
+
+Magnitude and phase
+===================
+
+.. code-block:: bash
+
+    patch-denoise \
+        sub-01/func/sub-01_task-rest_part-mag_bold.nii.gz \
+        sub-01_task-rest_part-mag_desc-denoised_bold.nii.gz \
+        --input-phase sub-01/func/sub-01_task-rest_part-phase_bold.nii.gz \
+        --mask auto \
+        --method optimal-fro \
+        --patch-shape 11 \
+        --patch-overlap 5 \
+        --recombination weighted \
+        --mask-threshold 1
+
+
+Magnitude and phase with noise volumes
+======================================
+
+.. code-block:: bash
+
+    patch-denoise \
+        sub-01/func/sub-01_task-rest_part-mag_bold.nii.gz \
+        sub-01_task-rest_part-mag_desc-denoised_bold.nii.gz \
+        --input-phase sub-01/func/sub-01_task-rest_part-phase_bold.nii.gz \
+        --noise-map sub-01/func/sub-01_task-rest_part-mag_noRF.nii.gz \
+        --noise-map-phase sub-01/func/sub-01_task-rest_part-phase_noRF.nii.gz \
+        --mask auto \
+        --method optimal-fro \
+        --patch-shape 11 \
+        --patch-overlap 5 \
+        --recombination weighted \
+        --mask-threshold 1

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,11 @@
+#########################################
+Using patch-denoise from the command line
+#########################################
+
+``patch-denoise`` minimally requires a path to a NIfTI file,
+but it can take advantage of reconstructed phase data and/or noise volumes.
+
+.. argparse::
+   :ref: patch_denoise.bindings.cli._get_parser
+   :prog: patch-denoise
+   :func: _get_parser

--- a/src/patch_denoise/bindings/cli.py
+++ b/src/patch_denoise/bindings/cli.py
@@ -280,6 +280,8 @@ def main():
         input_data, affine = load_complex_nifti(args.input_file, args.input_phase)
     input_data, affine = load_as_array(args.input_file)
 
+    kwargs = args.extra
+
     if args.nan_to_num is not None:
         input_data = np.nan_to_num(input_data, nan=args.nan_to_num)
     n_nans = np.isnan(input_data).sum()
@@ -326,7 +328,6 @@ def main():
         args.patch_shape = (args.patch_shape,) * (input_data.ndim - 1) + (t,)
 
     denoise_func = DENOISER_MAP[args.method]
-    extra_kwargs = dict()
 
     if args.method in [
         "nordic",
@@ -334,7 +335,7 @@ def main():
         "adaptive-qut",
         "optimal-fro-noise",
     ]:
-        extra_kwargs["noise_std"] = noise_map
+        kwargs["noise_std"] = noise_map
         if noise_map is None:
             raise RuntimeError("A noise map must be specified for this method.")
 
@@ -345,8 +346,7 @@ def main():
         mask=mask,
         mask_threshold=args.mask_threshold,
         recombination=args.recombination,
-        **extra_kwargs,
-        **args.extra,
+        **kwargs,
     )
 
     save_array(denoised_data, affine, args.output_file)

--- a/src/patch_denoise/bindings/cli.py
+++ b/src/patch_denoise/bindings/cli.py
@@ -77,8 +77,7 @@ class ToDict(argparse.Action):
         setattr(namespace, self.dest, d)
 
 
-def parse_args():
-    """Parse input arguments."""
+def _get_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -255,7 +254,12 @@ def parse_args():
         default=0,
         help="Increase verbosity level. You can provide multiple times (e.g., -vvv).",
     )
+    return parser
 
+
+def parse_args():
+    """Parse input arguments."""
+    parser = _get_parser()
     args = parser.parse_args()
 
     # default value for output.


### PR DESCRIPTION
Closes #9.

Changes proposed:

- Reorganize the argument parser.
- Add individual parameters as an alternative to the configuration string:
    - `--method`: One of the denoising methods. Default is "optimal-fro". This parameter is mutually exclusive with `--conf`.
    - `--patch-shape`: Positive integer. Default is 11.
    - `--patch-overlap`: Positive integer. Default is 5.
    - `--recombination`: "weighted" or "mean". Default is "weighted".
    - `--mask-threshold`: Integer. Default is 10. I noticed this was in the `DenoiseParameters`, but wasn't documented in the `--conf` description.
- Check values with custom argument types and actions.