### PR TITLE
Add usage page to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,3 +13,4 @@
    api
    denoisers
    auto_examples/index
+   usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,12 @@ classifiers = [
 [project.optional-dependencies]
 optional = ["modopt", "nipype", "numba"]
 test = ["pytest", "pytest-cov", "pytest-xdist", "pytest-sugar"]
-# sphinx 6 failes with pydata, sphinx 5 with sphinx gallery...
-doc = ["pydata-sphinx-theme", "numpydoc", "sphinx_gallery", "sphinx<5"]
+doc = [
+  "pydata-sphinx-theme",
+  "numpydoc",
+  "sphinx_gallery",
+  "sphinx",
+]
 dev = ["black", "isort", "ruff"]
 
 [project.scripts]


### PR DESCRIPTION
Closes none. I added a usage page in #11, but forgot to add it to the index toc. I also noticed that the docs build job is failing because of clashing dependency versions. I think those issues are resolved, so I unpinned sphinx.