### PR TITLE
[MAINT] fix pytest deprecation

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -4,13 +4,13 @@ import runpy
 import pytest
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(file_path: Path, parent):
     """Pytest hook.
 
     Create a collector for the given path, or None if not relevant.
     The new node needs to have the specified parent as parent.
     """
-    p = Path(path)
+    p = Path(file_path)
     if p.suffix == ".py" and "example" in p.name:
         return Script.from_parent(parent, path=p, name=p.name)
 


### PR DESCRIPTION
See

```
  /home/runner/work/patch-denoising/patch-denoising/examples/conftest.py:7: PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (file_path: pathlib.Path)
  see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
    def pytest_collect_file(path, parent):
```

https://github.com/paquiteau/patch-denoising/actions/runs/11210759102/job/31158264458#step:5:56